### PR TITLE
Check if module importable, add shared scheme for Carthage support

### DIFF
--- a/SBAutoLayout/SBAutoLayout.xcodeproj/xcshareddata/xcschemes/SBAutoLayout.xcscheme
+++ b/SBAutoLayout/SBAutoLayout.xcodeproj/xcshareddata/xcschemes/SBAutoLayout.xcscheme
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1010"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "677F421D1F9F235700BBD071"
+               BuildableName = "SBAutoLayout.framework"
+               BlueprintName = "SBAutoLayout"
+               ReferencedContainer = "container:SBAutoLayout.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "677F42261F9F235700BBD071"
+               BuildableName = "SBAutoLayoutTests.xctest"
+               BlueprintName = "SBAutoLayoutTests"
+               ReferencedContainer = "container:SBAutoLayout.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "677F421D1F9F235700BBD071"
+            BuildableName = "SBAutoLayout.framework"
+            BlueprintName = "SBAutoLayout"
+            ReferencedContainer = "container:SBAutoLayout.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "677F421D1F9F235700BBD071"
+            BuildableName = "SBAutoLayout.framework"
+            BlueprintName = "SBAutoLayout"
+            ReferencedContainer = "container:SBAutoLayout.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "677F421D1F9F235700BBD071"
+            BuildableName = "SBAutoLayout.framework"
+            BlueprintName = "SBAutoLayout"
+            ReferencedContainer = "container:SBAutoLayout.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/SBAutoLayout/SBAutoLayout/SBAutoLayout.swift
+++ b/SBAutoLayout/SBAutoLayout/SBAutoLayout.swift
@@ -8,14 +8,14 @@
 
 import Foundation
 
-#if os(OSX)
-    import AppKit
-    public typealias UIView = NSView
-    public typealias UILayoutPriority = NSLayoutConstraint.Priority
-    public typealias UIEdgeInsets = NSEdgeInsets
-    public typealias NSLayoutAttribute = NSLayoutConstraint.Attribute
-#else
+#if canImport(UIKit)
     import UIKit
+#else
+  import AppKit
+  public typealias UIView = NSView
+  public typealias UILayoutPriority = NSLayoutConstraint.Priority
+  public typealias UIEdgeInsets = NSEdgeInsets
+  public typealias NSLayoutAttribute = NSLayoutConstraint.Attribute
 #endif
 
 extension UIView {


### PR DESCRIPTION
- Using swift check for importable Module as described [here](https://github.com/apple/swift-evolution/blob/master/proposals/0075-import-test.md)
- Added shared scheme which allows this framework to be used with Carthage


The launch on login PR for TopDrawer will follow another time:)